### PR TITLE
Remove placeholder import_cis_cip_bdpm

### DIFF
--- a/import_structured_data.py
+++ b/import_structured_data.py
@@ -75,9 +75,6 @@ def import_cis_bdpm(cursor: sqlite3.Cursor, file_path: Path):
     return unique_cis_set, imported_count, skipped_count
 
 # Placeholder for other import functions (will be added incrementally)
-def import_cis_cip_bdpm(cursor: sqlite3.Cursor, file_path: Path):
-    print(f"Placeholder: Importing data from {file_path.name} into Presentations table...")
-    return 0, 0
 
 def import_cis_cip_bdpm(cursor: sqlite3.Cursor, file_path: Path):
     """Imports data from CIS_CIP_bdpm.txt into Presentations table."""


### PR DESCRIPTION
## Summary
- drop redundant placeholder `import_cis_cip_bdpm` definition

## Testing
- `python -m py_compile import_structured_data.py`
- `python -m py_compile database_setup.py`

------
https://chatgpt.com/codex/tasks/task_e_684202db41c88321b33a6415f5c04f28