### PR TITLE
Update section handling in transformer

### DIFF
--- a/transformer_dp_updated.py
+++ b/transformer_dp_updated.py
@@ -44,10 +44,6 @@ PREDEFINED_COLUMNS_STRUCTURE = {
     "dosimetrie": "TEXT",
     "instructions_pour_la_preparation_des_radiopharmaceutiques": "TEXT",
     "conditions_de_prescription_et_de_delivrance": "TEXT"
-    ,"col_donnees_cliniques": "TEXT"
-    ,"col_proprietes_pharmacologiques": "TEXT"
-    ,"col_donnees_pharmaceutiques": "TEXT"
-    ,"col_informations_complementaires": "TEXT"
 }
 OTHER_SECTIONS_COL_NAME = "other_parsed_sections_json"
 IGNORE_SECTION_MARKER = "_IGNORE_THIS_SECTION_" 
@@ -135,10 +131,10 @@ def initialize_target_title_map():
     TARGET_TITLE_TO_DB_COLUMN_MAP[clean_title_for_mapping("Conditions de prescription et de délivrance")] = "conditions_de_prescription_et_de_delivrance"
 
     # Titres de section de haut niveau 
-    TARGET_TITLE_TO_DB_COLUMN_MAP[clean_title_for_mapping("Données cliniques")] = "col_donnees_cliniques"
-    TARGET_TITLE_TO_DB_COLUMN_MAP[clean_title_for_mapping("Propriétés pharmacologiques")] = "col_proprietes_pharmacologiques"
-    TARGET_TITLE_TO_DB_COLUMN_MAP[clean_title_for_mapping("Données pharmaceutiques")] = "col_donnees_pharmaceutiques"
-    TARGET_TITLE_TO_DB_COLUMN_MAP[clean_title_for_mapping("Informations complementaires")] = "col_informations_complementaires"
+    TARGET_TITLE_TO_DB_COLUMN_MAP[clean_title_for_mapping("Données cliniques")] = IGNORE_SECTION_MARKER
+    TARGET_TITLE_TO_DB_COLUMN_MAP[clean_title_for_mapping("Propriétés pharmacologiques")] = IGNORE_SECTION_MARKER
+    TARGET_TITLE_TO_DB_COLUMN_MAP[clean_title_for_mapping("Données pharmaceutiques")] = IGNORE_SECTION_MARKER
+    TARGET_TITLE_TO_DB_COLUMN_MAP[clean_title_for_mapping("Informations complementaires")] = IGNORE_SECTION_MARKER
     
     # Autres titres à ignorer spécifiquement
     TARGET_TITLE_TO_DB_COLUMN_MAP[clean_title_for_mapping("Retour en haut de la page")] = IGNORE_SECTION_MARKER


### PR DESCRIPTION
## Summary
- remove previously defined high-level columns from `PREDEFINED_COLUMNS_STRUCTURE`
- ignore high-level sections when mapping titles

## Testing
- `python -m py_compile transformer_dp_updated.py`

------
https://chatgpt.com/codex/tasks/task_e_68421c8dc6e08321a7f4d71ee6e1cc80